### PR TITLE
Fix header to older version

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -6,14 +6,12 @@
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
     <meta http-equiv="Pragma" content="no-cache">
     <meta http-equiv="Expires" content="0">
-    <title>Course Materials Assistant</title>
+    <title>RAG Chat</title>
     <link rel="stylesheet" href="style.css?v=9">
 </head>
 <body>
     <div class="container">
         <header>
-            <h1>Course Materials Assistant</h1>
-            <p class="subtitle">Ask questions about courses, instructors, and content</p>
             <button id="themeToggle" class="theme-toggle" aria-label="Toggle theme" title="Switch between light and dark theme">
                 <svg class="sun-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                     <circle cx="12" cy="12" r="5"></circle>

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -78,32 +78,17 @@ body {
     padding: 0;
 }
 
-/* Header - Visible with Toggle Button */
+/* Header - Minimal with just Toggle Button */
 header {
     display: flex;
-    justify-content: space-between;
+    justify-content: flex-end;
     align-items: center;
     padding: 1rem 2rem;
-    background: var(--surface);
-    border-bottom: 1px solid var(--border-color);
+    background: var(--background);
     flex-shrink: 0;
 }
 
-header h1 {
-    font-size: 1.75rem;
-    font-weight: 700;
-    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
-    background-clip: text;
-    margin: 0;
-}
-
-.subtitle {
-    font-size: 0.95rem;
-    color: var(--text-secondary);
-    margin-top: 0.5rem;
-}
+/* Removed header h1 and subtitle styles as they're no longer needed */
 
 /* Main Content Area with Sidebar */
 .main-content {


### PR DESCRIPTION
Removes Course Materials Assistant title, subtitle, and horizontal border while preserving theme toggle functionality.

Resolves #2

🤖 Generated with [Claude Code](https://claude.ai/code)